### PR TITLE
lima/devel - Fixes for charged track propagation

### DIFF
--- a/examples/geometry/NavigationBenchmark.cpp
+++ b/examples/geometry/NavigationBenchmark.cpp
@@ -12,7 +12,6 @@
 
 #ifdef VECGEOM_ROOT
 #include "VecGeom/management/RootGeoManager.h"
-#include "VecGeom/utilities/Visualizer.h"
 #endif
 
 #ifdef VECGEOM_GEANT4
@@ -162,41 +161,6 @@ int main(int argc, char *argv[])
 #ifdef VECGEOM_GEANT4
   auto g4geom = geometry + ".gdml";
   G4GeoManager::Instance().LoadG4Geometry(g4geom.c_str());
-#endif
-
-// Visualization
-#ifdef VECGEOM_ROOT
-  if (vis) { // note that visualization block returns, excluding the rest of benchmark
-    Visualizer visualizer;
-    const VPlacedVolume *visWorld = GeoManager::Instance().GetWorld();
-    visualizer.AddVolume(*visWorld);
-
-    Vector<Daughter> const *daughters = visWorld->GetLogicalVolume()->GetDaughtersp();
-    for (size_t i = 0; i < daughters->size(); ++i) {
-      VPlacedVolume const *daughter = (*daughters)[i];
-      Transformation3D const &trf1  = *(daughter->GetTransformation());
-      visualizer.AddVolume(*daughter, trf1);
-
-      Vector<Daughter> const* daughters2 = daughter->GetLogicalVolume()->GetDaughtersp();
-      for (int ii=0; ii < (int)daughters2->size(); ++ii) {
-	VPlacedVolume const* daughter2 = (*daughters2)[ii];
-	Transformation3D const& trf2 = *(daughter2->GetTransformation());
-	Transformation3D comb = trf1;
-	comb.MultiplyFromRight(trf2);
-	visualizer.AddVolume(*daughter2, comb);
-      }
-    }
-
-    std::vector<VPlacedVolume *> v1;
-    GeoManager::Instance().getAllPlacedVolumes(v1);
-    for (auto &plvol : v1) {
-      std::cerr << "placedVol=" << plvol << ", name=" << plvol->GetName() << ", world=" << visWorld << ", <"
-                << visWorld->GetName() << ", " << GeoManager::Instance().GetWorld() << ">\n";
-    }
-
-    // visualizer.Show();
-    return 0;
-  }
 #endif
 
   std::cout << "\n*** Validating VecGeom navigation...\n";

--- a/source/Geant/core/src/LinearPropagationHandler.cpp
+++ b/source/Geant/core/src/LinearPropagationHandler.cpp
@@ -82,8 +82,7 @@ bool LinearPropagationHandler::IsSameLocation(TrackState &track, TaskData *td) c
   bool same = NavigationInterface::IsSameLocation(track); // always updates track's fNextpath
   if (same) return true;
   if (track.fGeometryState.fNextpath->IsOutside())
-    // killing the track while ExitingSetup does not stop it
-    track.fStatus = TrackStatus::Killed;  // TrackStatus::ExitingSetup;
+    track.fStatus = TrackStatus::ExitingSetup;
   return false;
 }
 

--- a/source/Geant/magneticfield/FieldPropagationHandler.hpp
+++ b/source/Geant/magneticfield/FieldPropagationHandler.hpp
@@ -31,10 +31,10 @@ public:
 
    VECCORE_ATT_HOST_DEVICE
    static void GetFieldValue(const ThreeVector_t &pos, ThreeVector_t &magFld, double &bmag) {
-      constexpr double kTeslaToKiloGauss = 10.0;
-      //magFld = ThreeVector_t{kTeslaToKiloGauss,kTeslaToKiloGauss,kTeslaToKiloGauss};
-      magFld = ThreeVector_t{0.0, 0.0, kTeslaToKiloGauss};
-      bmag = 3; 
+     constexpr double _bmag          = 3 * units::tesla;
+     static const ThreeVector_t _bfield = ThreeVector_t{0.0, 0.0, _bmag};
+     bmag   = _bmag;
+     magFld = _bfield;
    }
 };
 

--- a/source/Geant/magneticfield/src/FieldPropagationHandler.cpp
+++ b/source/Geant/magneticfield/src/FieldPropagationHandler.cpp
@@ -73,25 +73,14 @@ double Charge(const TrackState &track)
 // Curvature for general field
 VECCORE_ATT_HOST_DEVICE
 double FieldPropagationHandler::Curvature(const TrackState &track,
-                                          const ThreeVector_t &magFld_in,
-                                          double bmag) const
+					    const ThreeVector_t &Bfield,
+					    double bmag) const
 {
-  // using ThreeVector_t            = vecgeom::Vector3D<double>;
-  constexpr double tiny          = 1.E-30;
-  constexpr double inv_kilogauss = 1.0 / units::kilogauss;
-
-  bmag *= inv_kilogauss;
-  ThreeVector_t magFld{magFld_in * inv_kilogauss};
-  //  Calculate transverse momentum 'Pt' for field 'B'
-  //
-  ThreeVector_t Momentum(track.fDir);
-  ThreeVector_t PtransB; //  Transverse wrt direction of B
-  double ratioOverFld = 0.0;
-  if (bmag > 0) ratioOverFld = Momentum.Dot(magFld) / (bmag * bmag);
-  PtransB       = Momentum - ratioOverFld * magFld;
-  double Pt_mag = PtransB.Mag();
-
-  return fabs(kB2C * Charge(track) * bmag / (Pt_mag + tiny));
+  assert(bmag > 0.0);
+  const double& pmag = track.fPhysicsState.fMomentum;
+  double plong = pmag * track.fDir.Dot(Bfield) / bmag;
+  double pt    = sqrt(pmag * pmag - plong * plong);
+  return units::kCLight * bmag / pt; // if bmag and pt are positive, no need to call fabs()
 }
 
 //______________________________________________________________________________

--- a/source/Geant/magneticfield/src/FieldPropagationHandler.cpp
+++ b/source/Geant/magneticfield/src/FieldPropagationHandler.cpp
@@ -212,19 +212,19 @@ void FieldPropagationHandler::PropagateInVolume(TrackState &track, double crtste
 #if ENABLE_MORE_COMPLEX_FIELD
   if (useRungeKutta || !fieldConfig->IsFieldUniform()) {
     assert(fieldPropagator);
-    fieldPropagator->DoStep(Position, Direction, track.Charge(), track.P(), crtstep,
+    fieldPropagator->DoStep(Position, Direction, Charge(track), track.P(), crtstep,
                             PositionNew, DirectionNew);
     assert((PositionNew - Position).Mag() < crtstep + 1.e-4);
 #  ifdef DEBUG_FIELD
 // cross check
 #    ifndef CHECK_VS_BZ
     ConstFieldHelixStepper stepper(BfieldInitial * toKiloGauss);
-    stepper.DoStep<double>(Position, Direction, track.Charge(), track.P(), crtstep,
+    stepper.DoStep<double>(Position, Direction, Charge(track), track.P(), crtstep,
                            PositionNewCheck, DirectionNewCheck);
 #    else
     double Bz = BfieldInitial[2] * toKiloGauss;
     ConstBzFieldHelixStepper stepper_bz(Bz); //
-    stepper_bz.DoStep<ThreeVector, double, int>(Position, Direction, track.Charge(),
+    stepper_bz.DoStep<ThreeVector, double, int>(Position, Direction, Charge(track),
                                                 track.P(), crtstep, PositionNewCheck,
                                                 DirectionNewCheck);
 #    endif

--- a/source/Geant/proxy/test/BasicCpuTransport/TrackManager.hpp
+++ b/source/Geant/proxy/test/BasicCpuTransport/TrackManager.hpp
@@ -90,8 +90,7 @@ struct TrackManager
         GEANT_THIS_TYPE_TESTING_MARKER("");
         if(!_track) return nullptr;
 
-        if(_track->fStatus == TrackStatus::Killed)
-        {
+	if( _track->fStatus == TrackStatus::Killed || _track->fStatus == TrackStatus::ExitingSetup ) {
             delete _track;
             return nullptr;
         }

--- a/source/Geant/proxy/test/BasicCpuTransport/Types.hpp
+++ b/source/Geant/proxy/test/BasicCpuTransport/Types.hpp
@@ -108,20 +108,24 @@ struct PhysicsProcessCombinedPostStep<ParticleType, std::tuple<ProcessTypes...>>
 //===----------------------------------------------------------------------===//
 
 using CpuGammaPhysics =
-    PhysicsProcessList<CpuGamma, ProxyCompton, ProxyConversion, ProxyPhotoElectric, ProxyScattering, 
-                       ProxyStepLimiter, ProxyTrackLimiter, ProxySecondaryGenerator>;
+  PhysicsProcessList<CpuGamma, ProxyTrackLimiter>;
+  // PhysicsProcessList<CpuGamma, ProxyCompton, ProxyConversion, ProxyPhotoElectric, //ProxyScattering, 
+  //                      ProxyStepLimiter, ProxyTrackLimiter, ProxySecondaryGenerator>;
 
 using CpuElectronPhysics =
-    PhysicsProcessList<CpuElectron, ProxyIonization, ProxyBremsstrahlung, ProxyScattering, ProxyStepLimiter, 
-                       ProxyTrackLimiter, ProxySecondaryGenerator>;
+  PhysicsProcessList<CpuElectron, ProxyTrackLimiter>;
+  // PhysicsProcessList<CpuElectron, ProxyIonization, ProxyBremsstrahlung, //ProxyScattering,
+  // 		     ProxyStepLimiter, ProxyTrackLimiter, ProxySecondaryGenerator>;
 
 using GpuGammaPhysics =
-    PhysicsProcessList<GpuGamma, ProxyCompton, ProxyConversion, ProxyPhotoElectric, ProxyScattering,
-                       ProxyStepLimiter, ProxyTrackLimiter, ProxySecondaryGenerator>;
+  PhysicsProcessList<GpuGamma, ProxyTrackLimiter>;
+  // PhysicsProcessList<GpuGamma, ProxyCompton, ProxyConversion, ProxyPhotoElectric, //ProxyScattering,
+  //                      ProxyStepLimiter, ProxyTrackLimiter, ProxySecondaryGenerator>;
 
 using GpuElectronPhysics =
-    PhysicsProcessList<GpuElectron, ProxyIonization, ProxyBremsstrahlung, ProxyScattering, ProxyStepLimiter,
-                       ProxyTrackLimiter, ProxySecondaryGenerator>;
+  PhysicsProcessList<GpuElectron, ProxyTrackLimiter>;
+  // PhysicsProcessList<GpuElectron, ProxyIonization, ProxyBremsstrahlung, //ProxyScattering,
+  // 		     ProxyStepLimiter, ProxyTrackLimiter, ProxySecondaryGenerator>;
 
 //===----------------------------------------------------------------------===//
 //              A list of all particle + physics pairs

--- a/source/Geant/proxy/test/test_BasicCpuTransport.cpp
+++ b/source/Geant/proxy/test/test_BasicCpuTransport.cpp
@@ -321,7 +321,7 @@ VECCORE_ATT_HOST_DEVICE
 GEANT_FORCE_INLINE
 bool Propagate(TrackState &track, PropagationHandler &h, TaskData *td)
 {
-    if ( ! h.Propagate(track, td)) { // updates:  fPstep -= step;  fStep += step;  fSnext -= step
+    if ( ! h.Propagate(track, td) ) { // updates:  fPstep -= step;  fStep += step;  fSnext -= step
       return false;
     }
     ++(track.fHistoryState.fNsteps);

--- a/source/Geant/proxy/test/test_BasicCpuTransport.cpp
+++ b/source/Geant/proxy/test/test_BasicCpuTransport.cpp
@@ -677,15 +677,17 @@ main(int argc, char** argv)
     // prepare primary tracks - TODO: use a particle gun
     double energy = 10. * geantx::units::GeV;
 
-    printf("* CpuGammas\n");
+    // printf("* CpuGammas\n");
     primary.PushTrack<CpuGamma>(get_primary_particle(energy));
-    primary.PushTrack<CpuGamma>(get_primary_particle(energy));
-    primary.PushTrack<CpuGamma>(get_primary_particle(energy));
-    primary.PushTrack<CpuGamma>(get_primary_particle(energy));
-    primary.PushTrack<CpuGamma>(get_primary_particle(energy));
-    primary.PushTrack<CpuGamma>(get_primary_particle(energy));
+    // primary.PushTrack<CpuGamma>(get_primary_particle(energy));
 
     printf("* CpuElectrons\n");
+    primary.PushTrack<CpuElectron>(get_primary_particle(energy));
+    primary.PushTrack<CpuElectron>(get_primary_particle(energy));
+    primary.PushTrack<CpuElectron>(get_primary_particle(energy));
+    primary.PushTrack<CpuElectron>(get_primary_particle(energy));
+    primary.PushTrack<CpuElectron>(get_primary_particle(energy));
+    primary.PushTrack<CpuElectron>(get_primary_particle(energy));
     primary.PushTrack<CpuElectron>(get_primary_particle(energy));
     primary.PushTrack<CpuElectron>(get_primary_particle(energy));
 

--- a/source/Geant/proxy/test/test_BasicCpuTransport.cpp
+++ b/source/Geant/proxy/test/test_BasicCpuTransport.cpp
@@ -560,6 +560,7 @@ get_primary_particle(double Ekin)
     Track* _track = new Track;
 
     //TrackModifier<CpuElectron> trk(_track);
+    //_track->fGeometryState.Initialize();
 
     //_track->fPhysicsState.fEkin  = Ekin;
     UpdateEkin(*_track, Ekin);

--- a/source/Geant/proxy/test/test_BasicCpuTransport.cpp
+++ b/source/Geant/proxy/test/test_BasicCpuTransport.cpp
@@ -675,7 +675,7 @@ main(int argc, char** argv)
     */
 
     // prepare primary tracks - TODO: use a particle gun
-    double energy = 10. * geantx::clhep::GeV;
+    double energy = 10. * geantx::units::GeV;
 
     printf("* CpuGammas\n");
     primary.PushTrack<CpuGamma>(get_primary_particle(energy));

--- a/source/Geant/track/TrackAccessor.hpp
+++ b/source/Geant/track/TrackAccessor.hpp
@@ -45,7 +45,7 @@ public:
 
     ParticleId_t  Id() const { return this->State().fHistoryState.fParticle; }
     TrackStatus Status() const { return this->State().fStatus; }
-    bool          Alive() const { return this->Status() != TrackStatus::Killed; }
+    bool        Alive()  const { return this->Status() != TrackStatus::Killed && this->Status() != TrackStatus::ExitingSetup; }
 
     double Momentum() const { return this->State().fPhysicsState.fMomentum; }
     double KineticEnergy() const { return this->State().fPhysicsState.fEkin; }

--- a/source/Geant/track/TrackState.hpp
+++ b/source/Geant/track/TrackState.hpp
@@ -99,16 +99,15 @@ struct TrackHistoryState
   }
 
     // TODO: fVolume is a cached 'fPath->Top()->GetLogicalVolume()'
-    Volume_t const* fVolume   = nullptr; /** Current volume the particle is in */
-    VolumePath_t*   fPath     = nullptr; /** Current volume state */
-    VolumePath_t*   fNextpath = nullptr; /** Next volume state */
-    double          fSnext    = 0;       /** Straight distance to next boundary */
-    double          fSafety   = 0;       /** Safe distance to any boundary */
-    bool            fIsOnBoundaryPreStp =
-        false;              /** Particle was on boundary at the pre-step point */
-    bool fBoundary = false; /** Starting from boundary */
-    bool fPending  = false; /** Track pending to be processed  (???) */
-};
+    Volume_t const* fVolume   = nullptr;          /** Current volume the particle is in */
+    VolumePath_t*   fPath     = nullptr;          /** Current volume state */
+    VolumePath_t*   fNextpath = nullptr;          /** Next volume state */
+    double          fSnext    = 0;                /** Straight distance to next boundary */
+    double          fSafety   = 0;                /** Safe distance to any boundary */
+    bool            fIsOnBoundaryPreStp = false;  /** Particle was on boundary at the pre-step point */
+    bool fBoundary = false;                       /** Starting from boundary */
+    bool fPending  = false;                       /** Track pending to be processed  (???) */
+  };
 
 struct TrackMaterialState
 {

--- a/source/Geant/track/TrackState.hpp
+++ b/source/Geant/track/TrackState.hpp
@@ -209,6 +209,10 @@ struct TrackState
     TrackMaterialState fMaterialState;
     TrackGeometryState fGeometryState;
 
+    double P() const {
+      return fPhysicsState.fMomentum;
+    }
+
     friend std::ostream& operator<<(std::ostream& os, const TrackState& t)
     {
         // the tuple<string> overload of tim::apply changes the definition of join


### PR DESCRIPTION
Mainly fixes to track energy units, to magnetic field properties and to handling of tracks exiting volume.

Note: all physics processes are temporarily disabled to check that tracks are propagated to boundarys.  More sanity checks are needed, but EM physics processes are currently making it very difficult to debug the propagation, so I have disabled them.  I suggest them to be validated individually before re-enabling.